### PR TITLE
Update checkstyle javadoc config

### DIFF
--- a/src/main/resources/org/danilopianini/javaqa/checkstyle.xml
+++ b/src/main/resources/org/danilopianini/javaqa/checkstyle.xml
@@ -50,18 +50,22 @@
             <property name="onCommentFormat" value="CHECKSTYLE: ([\w\|]+) ON"/>
             <property name="checkFormat" value="$1"/>
         </module>
-        <!-- Checks for Javadoc comments. -->
+        <!-- Checks for missing Javadoc comments. -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-        <module name="JavadocMethod">
-            <property name="accessModifiers" value="protected"/>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="protected"/>
         </module>
-        <module name="JavadocType">
+        <module name="MissingJavadocType">
             <property name="severity" value="error"/>
             <property name="scope" value="protected"/>
         </module>
         <module name="JavadocVariable">
             <property name="scope" value="protected"/>
         </module>
+        <!-- Checks for well-formed Javadoc comments. -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <module name="JavadocMethod"/>
+        <module name="JavadocType"/>
         <module name="JavadocStyle"/>
         <!-- Checks for Naming Conventions. -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->


### PR DESCRIPTION
`JavadocMethod` and `JavadocType` rules only check if the javadoc for method and types is well-formed, but won't give a warning on missing javadoc.
- Add `MissingJavadocMethod` and `MissingJavadocType` to check for missing javadoc on public or protected methods and types
- Change `JavadocMethod` and `JavadocType` to check if javadoc of methods/types is well-formed even on private and package methods/types, if present